### PR TITLE
Adds the ability to send cache control headers on each reply

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -14,6 +14,7 @@ const path = require('path'),
     healthChecks = cnnhealth(path.resolve(__dirname, './config/healthcheck'));
 
 let app = module.exports = hapi({
+    cacheControlType: 'browser',
     directory: __dirname,
     port: process.env.PORT,
     withSwagger: true,

--- a/example/app.js
+++ b/example/app.js
@@ -14,14 +14,15 @@ const path = require('path'),
     healthChecks = cnnhealth(path.resolve(__dirname, './config/healthcheck'));
 
 let app = module.exports = hapi({
-    cacheControlType: 'browser',
     directory: __dirname,
     port: process.env.PORT,
     withSwagger: true,
     withNavigation: false,
     metrics: {provider: require('cnn-metrics'), options: {flushEvery: 20 * 1000}},
     layoutsDir: `${__dirname}/views/`,
-    healthChecks: healthChecks.asArray()
+    healthChecks: healthChecks.asArray(),
+    maxAge: '10',
+    surrogateCacheControl: 'max-age=60, stale-while-revalidate=10, stale-if-error=6400'
 });
 
 app.route({

--- a/main.js
+++ b/main.js
@@ -54,23 +54,22 @@ let setupHealthCheck = function (request, reply) {
     metricsProvider = {};
 
 /**
- * Setup static content cache control headers
- * @private
- * @param {object} request - Request object
- */
-function getStaticCacheControlHeaders(request) {
-    request.response.header('Surrogate-Control', cdnSurrogateControl);
-    request.response.header('Cache-Control', cdnCacheControl);
-}
-
-/**
  * Set up cache control headers
  * @private
  * @param {object} request - Request object
+ * @param {string} cacheControlType - The cache control header to set
  */
-function getCacheControlHeaders(request) {
-    request.response.header('Surrogate-Control', surrogateControlHeader);
-    request.response.header('Cache-Control', cacheControlHeader);
+function getCacheControlHeaders(request, cacheControlType) {
+    switch (cacheControlType) {
+        case 'cdn':
+            request.response.header('Surrogate-Control', cdnSurrogateControl);
+            request.response.header('Cache-Control', cdnCacheControl);
+            break;
+        case 'browser':
+            request.response.header('Surrogate-Control', surrogateControlHeader);
+            request.response.header('Cache-Control', cacheControlHeader);
+            break;
+    }
 }
 
 module.exports = function (options) {
@@ -186,14 +185,7 @@ module.exports = function (options) {
     server.ext({
         type: 'onPreResponse',
         method: function (request, reply) {
-            switch (cacheControlType) {
-                case 'cdn':
-                    getCacheControlHeaders(request);
-                    break;
-                case 'browser':
-                    getStaticCacheControlHeaders(request);
-                    break;
-            }
+            getCacheControlHeaders(request, cacheControlType);
             return reply.continue();
         }
     });

--- a/main.js
+++ b/main.js
@@ -88,7 +88,7 @@ module.exports = function (options) {
         directory = options.directory || process.cwd(),
         actualAppStart,
         cacheControlHeader = process.env.CACHE_CONTROL || options.maxAge || 'max-age=60', // Default cache time is 60 seconds
-        surrogateControlHeader = process.env.SURROGATE_CACHE_CONTROL || options.surrogateCacheControl || 'max-age=360, stale-while-revalidate=60, stale-if-error=86400', // Default from Fastly
+        surrogateControlHeader = process.env.SURROGATE_CACHE_CONTROL || options.surrogateCacheControl || 'max-age=360, stale-while-revalidate=60, stale-if-error=86400',
         cacheHeaders = {
             cacheControlHeader: cacheControlHeader,
             surrogateCacheControl: surrogateControlHeader

--- a/main.js
+++ b/main.js
@@ -55,7 +55,7 @@ let setupHealthCheck = function (request, reply) {
  * @param {object} request - Request object
  * @param {object} headers - The cache control headers to set
  */
-function getCacheControlHeaders(request, headers) {
+function setCacheControlHeaders(request, headers) {
     let surrogateControl = headers.surrogateCacheControl ? headers.surrogateCacheControl : false,
         cacheControl = headers.cacheControlHeader ? headers.cacheControlHeader : false;
 
@@ -186,7 +186,7 @@ module.exports = function (options) {
     server.ext({
         type: 'onPreResponse',
         method: function (request, reply) {
-            getCacheControlHeaders(request, cacheHeaders);
+            setCacheControlHeaders(request, cacheHeaders);
             return reply.continue();
         }
     });

--- a/main.js
+++ b/main.js
@@ -94,7 +94,7 @@ module.exports = function (options) {
         description = '',
         directory = options.directory || process.cwd(),
         actualAppStart,
-        cacheControlType = options.cacheControlType || 'browser'; //cdn || browser
+        cacheControlType = process.env.CACHE_CONTROL_TYPE || options.cacheControlType; //cdn || browser
 
     options = options || {};
     options = Hoek.applyToDefaults(defaults, options);

--- a/main.js
+++ b/main.js
@@ -57,9 +57,8 @@ let setupHealthCheck = function (request, reply) {
  * Setup static content cache control headers
  * @private
  * @param {object} request - Request object
- * @param {object} reply - Response object
  */
-function getStaticCacheControlHeaders(request, reply) {
+function getStaticCacheControlHeaders(request) {
     request.response.header('Surrogate-Control', cdnSurrogateControl);
     request.response.header('Cache-Control', cdnCacheControl);
 }
@@ -68,9 +67,8 @@ function getStaticCacheControlHeaders(request, reply) {
  * Set up cache control headers
  * @private
  * @param {object} request - Request object
- * @param {object} reply - Response object
  */
-function getCacheControlHeaders(request, reply) {
+function getCacheControlHeaders(request) {
     request.response.header('Surrogate-Control', surrogateControlHeader);
     request.response.header('Cache-Control', cacheControlHeader);
 }
@@ -190,10 +188,10 @@ module.exports = function (options) {
         method: function (request, reply) {
             switch (cacheControlType) {
                 case 'cdn':
-                    getCacheControlHeaders(request, reply);
+                    getCacheControlHeaders(request);
                     break;
                 case 'browser':
-                    getStaticCacheControlHeaders(request, reply);
+                    getStaticCacheControlHeaders(request);
                     break;
             }
             return reply.continue();


### PR DESCRIPTION
## Why

Adds the ability to set cache control headers on each reply

## How to test

From the root of this project along with these changes run the following example/app.js:

### Terminal  1
```
$ cd example/
$ node app.js
```

### Terminal 2
```
$ curl -I http://{your-app-host}
```

### Should see a response similar to the following
```
HTTP/1.1 200 OK
surrogate-control: max-age=60, stale-while-revalidate=10, stale-if-error=6400
cache-control: 10
content-type: text/html; charset=utf-8
date: Thu, 17 Mar 2016 01:20:48 GMT
X-BACKEND: apps-proxy
```

