### PR TITLE
Adding checks around response.header

### DIFF
--- a/main.js
+++ b/main.js
@@ -59,12 +59,16 @@ function setCacheControlHeaders(request, headers) {
     let surrogateControl = headers.surrogateCacheControl ? headers.surrogateCacheControl : false,
         cacheControl = headers.cacheControlHeader ? headers.cacheControlHeader : false;
 
-    if (typeof surrogateControl === 'string') {
-        request.response.header('Surrogate-Control', surrogateControl);
-    }
+    if (typeof request.response === 'object' &&
+        request.response !== null &&
+        typeof request.response.header === 'function') {
+        if (typeof surrogateControl === 'string') {
+            request.response.header('Surrogate-Control', surrogateControl);
+        }
 
-    if (typeof cacheControl === 'string') {
-        request.response.header('Cache-Control', cacheControl);
+        if (typeof cacheControl === 'string') {
+            request.response.header('Cache-Control', cacheControl);
+        }
     }
 }
 


### PR DESCRIPTION
# Why
Addresses https://github.com/cnnlabs/cnn-hapi/issues/13

Adding checks to prevent this error
```
Debug: internal, implementation, error 
    TypeError: Uncaught error: request.response.header is not a function
    at setCacheControlHeaders (/home/ubuntu/workspace/main.js:63:26)
    at server.route.server.ext.method (/home/ubuntu/workspace/main.js:189:13)
    at /home/ubuntu/workspace/node_modules/hapi/lib/request.js:402:22
    at iterate (/home/ubuntu/workspace/node_modules/hapi/node_modules/items/lib/index.js:36:13)
    at done (/home/ubuntu/workspace/node_modules/hapi/node_modules/items/lib/index.js:28:25)
    at Function.wrapped [as _next] (/home/ubuntu/workspace/node_modules/hoek/lib/index.js:867:20)
    at Function.internals.Reply.interface.internals.continue (/home/ubuntu/workspace/node_modules/hapi/lib/reply.js:107:10)
    at server.ext.method (/home/ubuntu/workspace/lib/plugins/metrics/index.js:16:34)
    at /home/ubuntu/workspace/node_modules/hapi/lib/request.js:402:22
    at iterate (/home/ubuntu/workspace/node_modules/hapi/node_modules/items/lib/index.js:36:13)
```