### PR TITLE
Adding a check around reply.set

### DIFF
--- a/lib/hapi/robots.js
+++ b/lib/hapi/robots.js
@@ -4,10 +4,12 @@ const fs = require('fs'),
     robots = fs.readFileSync(`${__dirname}/robots.txt`, {encoding: 'utf8'});
 
 module.exports = function (request, reply) {
-    reply.set({
-        'Content-Type': 'text/plain',
-        'Cache-Control': 'max-age:3600, public'
-    });
+    if (reply.set && typeof reply.set === 'function') {
+        reply.set({
+            'Content-Type': 'text/plain',
+            'Cache-Control': 'max-age:3600, public'
+        });
+    }
 
     reply.send(robots);
 };


### PR DESCRIPTION
# Why

Addresses https://github.com/cnnlabs/cnn-hapi/issues/15

Handles this exception:

```
2016-03-18T18:36:54.623407561Z Debug: internal, implementation, error 
2016-03-18T18:36:54.623431191Z     TypeError: Uncaught error: reply.set is not a function
2016-03-18T18:36:54.623443219Z     at module.exports (/cnn-login-app/node_modules/cnn-hapi/lib/hapi/robots.js:7:11)
2016-03-18T18:36:54.623452128Z     at Object.exports.execute.internals.prerequisites.internals.handler.callback [as handler] (/cnn-login-app/node_modules/hapi/lib/handler.js:96:36)
2016-03-18T18:36:54.623460913Z     at /cnn-login-app/node_modules/hapi/lib/handler.js:30:23
2016-03-18T18:36:54.623468254Z     at internals.Protect.run.finish [as run] (/cnn-login-app/node_modules/hapi/lib/protect.js:64:5)
2016-03-18T18:36:54.623475612Z     at exports.execute.finalize (/cnn-login-app/node_modules/hapi/lib/handler.js:24:22)
2016-03-18T18:36:54.623483560Z     at each (/cnn-login-app/node_modules/hapi/lib/request.js:383:16)
2016-03-18T18:36:54.623491873Z     at iterate (/cnn-login-app/node_modules/hapi/node_modules/items/lib/index.js:36:13)
2016-03-18T18:36:54.623499352Z     at done (/cnn-login-app/node_modules/hapi/node_modules/items/lib/index.js:28:25)
2016-03-18T18:36:54.623506611Z     at internals.Auth.test.internals.Auth._authenticate (/cnn-login-app/node_modules/hapi/lib/auth.js:210:16)
2016-03-18T18:36:54.623513844Z     at internals.Auth.test.internals.Auth.authenticate (/cnn-login-app/node_modules/hapi/lib/auth.js:202:17)
```