### PR TITLE
swagger: full support for current swagger options info

### DIFF
--- a/main.js
+++ b/main.js
@@ -140,13 +140,31 @@ module.exports = function (options) {
 
     if (options.withSwagger) {
         server.register(require('vision'), () => {});
+
+        let swaggerOptionsInfo = {};
+
+        swaggerOptionsInfo.title = options.name || undefined;
+        swaggerOptionsInfo.description = options.description || undefined;
+        swaggerOptionsInfo.termsOfService = options.termsOfService || undefined;
+        swaggerOptionsInfo.version = options.version || undefined;
+
+        if (options.contactName || options.contactEmail || options.contactUrl) {
+            swaggerOptionsInfo.contact = {};
+            swaggerOptionsInfo.contact.name = options.contactName || undefined;
+            swaggerOptionsInfo.contact.email = options.contactEmail || undefined;
+            swaggerOptionsInfo.contact.url = options.contactUrl || undefined;
+        }
+
+        if (options.licenseName || options.licenseUrl) {
+            swaggerOptionsInfo.license = {};
+            swaggerOptionsInfo.license.name = options.licenseName || undefined;
+            swaggerOptionsInfo.license.url = options.licenseUrl || undefined;
+        }
+
         server.register({
             register: require('hapi-swagger'),
             options: {
-                info: {
-                    title: options.name,
-                    description: options.description
-                }
+                info: swaggerOptionsInfo
             }
         });
     }


### PR DESCRIPTION
Supports setting the title, description, terms of service, version,
contact details (name, email, and url), and license details (name, and url).

I mainly did this to get the version to show up, then I saw all the other options that can be set.

It looks like this in the UI (not extremely pretty when all options are populated)

![](http://new.tinygrab.com/d34460e816f285515322d27fbe3385738db9aa8d4e.png)