### PR TITLE
add lodash to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "inert": "4.0.1",
     "isomorphic-fetch": "2.2.1",
     "joi": "9.0.4",
+    "lodash": "4.14.2",
     "socket.io": "1.4.8",
     "vision": "4.1.0"
   },


### PR DESCRIPTION
# Why

At some point lodash was added but not to the main package.json. This adds it. It is odd that things work without it defined in the main package.json