### PR TITLE
Feature/custom headers

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -7,11 +7,11 @@
  *
  * See the comments inline for changes that would be typical in an external app
  */
-
 const path = require('path'),
     hapi = require('../main'), // hapi = require('cnn-hapi'),
     cnnhealth = require('cnn-health'),
     otherChecks = require('./config/otherchecks');
+
 let healthChecks = cnnhealth(path.resolve(__dirname, './config/healthcheck')).asArray(),
     app;
 
@@ -27,13 +27,19 @@ app = module.exports = hapi({
     layoutsDir: `${__dirname}/views/`,
     healthChecks: healthChecks,
     maxAge: '10',
-    surrogateCacheControl: 'max-age=60, stale-while-revalidate=10, stale-if-error=6400'
+    surrogateCacheControl: 'max-age=60, stale-while-revalidate=10, stale-if-error=6400',
+    customHeaders: [
+        {
+            name: 'test-header',
+            value: 'test-header-value'
+        }
+    ]
 });
 
 app.route({
     method: 'GET',
     path: '/',
-    handler: function (request, reply) {
+    handler: function routeHandler(request, reply) {
         reply('Hello router');
     }
 });

--- a/example/app.js
+++ b/example/app.js
@@ -30,8 +30,8 @@ app = module.exports = hapi({
     surrogateCacheControl: 'max-age=60, stale-while-revalidate=10, stale-if-error=6400',
     customHeaders: [
         {
-            name: 'test-header',
-            value: 'test-header-value'
+            name: 'Connection',
+            value: 'close'
         }
     ]
 });

--- a/main.js
+++ b/main.js
@@ -94,11 +94,15 @@ function setCacheControlHeaders(request, headers) {
  * @param {object} customHeaders - The custome headers to set
  */
 function setCustomHeaders(request, customHeaders) {
-    let header;
+    let header,
+        length,
+        i = 0;
 
     if (hasHeaders(request)) {
-        for (header in customHeaders) {
-            if (customHeaders.hasOwnProperty(header)) {
+        length = customHeaders.length;
+        for (; i < length; i++) {
+            header = customHeaders[i];
+            if (header.name && header.value) {
                 request.repsonse.header(header.name, header.value);
             }
         }
@@ -135,7 +139,7 @@ module.exports = function (options) {
         connectionOptions = {
             port: port
         },
-        customHeaders = (options.customHeaders) ? options.customHeaders : {};
+        customHeaders = (options.customHeaders) ? options.customHeaders : [];
 
     if (options.routes) {
         connectionOptions.routes = options.routes;

--- a/main.js
+++ b/main.js
@@ -76,7 +76,7 @@ function setCacheControlHeaders(request, headers) {
     let surrogateControl = headers.surrogateCacheControl ? headers.surrogateCacheControl : false,
         cacheControl = headers.cacheControlHeader ? headers.cacheControlHeader : false;
 
-    if (hasHeaders(request)) {
+    if (hasHeaders(request) === true) {
         if (typeof surrogateControl === 'string') {
             request.response.header('Surrogate-Control', surrogateControl);
         }
@@ -98,7 +98,7 @@ function setCustomHeaders(request, customHeaders) {
         length,
         i = 0;
 
-    if (hasHeaders(request)) {
+    if (hasHeaders(request) === true) {
         length = customHeaders.length;
         for (; i < length; i++) {
             header = customHeaders[i];

--- a/main.js
+++ b/main.js
@@ -103,7 +103,7 @@ function setCustomHeaders(request, customHeaders) {
         for (; i < length; i++) {
             header = customHeaders[i];
             if (header.name && header.value) {
-                request.repsonse.header(header.name, header.value);
+                request.response.header(header.name, header.value);
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "inert": "4.0.1",
     "isomorphic-fetch": "2.2.1",
     "joi": "9.0.4",
+    "lodash": "4.14.2",
     "socket.io": "1.4.8",
     "vision": "4.1.0"
   },


### PR DESCRIPTION
# Why

Add the ability set custom headers

# Testing

1. run `PORT=5000 node example/app.js`
2. then run `curl -I localhost:5000`
3. output similar to below should be seen as the custom app is setting `connection: close`

```
HTTP/1.1 200 OK
surrogate-control: max-age=60, stale-while-revalidate=10, stale-if-error=6400
cache-control: 10
connection: close
content-type: text/html; charset=utf-8
Date: Wed, 10 Aug 2016 13:23:34 GMT
```

