### PR TITLE
Providing a way for route and state config to be passed

### DIFF
--- a/main.js
+++ b/main.js
@@ -153,10 +153,10 @@ module.exports = function (argumentOptions) {
         connectionOptions.routes = options.routes;
     }
 
-    if (_.get(options, "connections.routes.files", false)) {
+    if (_.get(options, 'connections.routes.files', false)) {
         server.settings.connections.routes.files = options.connections.routes.files;
     }
-    if (_.get(options, "connections.routes.state", false)) {
+    if (_.get(options, 'connections.routes.state', false)) {
         server.settings.connections.routes.state = options.connections.routes.state;
     }
 

--- a/main.js
+++ b/main.js
@@ -153,11 +153,8 @@ module.exports = function (argumentOptions) {
         connectionOptions.routes = options.routes;
     }
 
-    if (_.get(options, 'connections.routes.files', false)) {
-        server.settings.connections.routes.files = options.connections.routes.files;
-    }
-    if (_.get(options, 'connections.routes.state', false)) {
-        server.settings.connections.routes.state = options.connections.routes.state;
+    if (_.get(options, 'connections', false)) {
+        server.settings.connections = options.connections;
     }
 
     server.connection(connectionOptions);

--- a/main.js
+++ b/main.js
@@ -149,12 +149,14 @@ module.exports = function (argumentOptions) {
         connectionOptions.tls = options.tls;
     }
 
-    if (options.routes) {
-        connectionOptions.routes = options.routes;
+    if (options.connections.routes) {
+        console.log("----- received and setting a route config from calling application");
+        server.settings.connections.routes.files = options.connections.routes.files;
     }
 
-    if (options.state) {
-        connectionOptions.state = options.state;
+    if (options.connections.routes.state) {
+        console.log("----- received and setting a state config from calling application");
+        server.settings.connections.routes.state = options.connections.routes.state;
     }
 
     server.connection(connectionOptions);

--- a/main.js
+++ b/main.js
@@ -149,13 +149,14 @@ module.exports = function (argumentOptions) {
         connectionOptions.tls = options.tls;
     }
 
-    if (options.connections.routes) {
-        console.log("----- received and setting a route config from calling application");
-        server.settings.connections.routes.files = options.connections.routes.files;
+    if (options.routes) {
+        connectionOptions.routes = options.routes;
     }
 
-    if (options.connections.routes.state) {
-        console.log("----- received and setting a state config from calling application");
+    if (_.get(options, "connections.routes.files", false)) {
+        server.settings.connections.routes.files = options.connections.routes.files;
+    }
+    if (_.get(options, "connections.routes.state", false)) {
         server.settings.connections.routes.state = options.connections.routes.state;
     }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "esdoc": "0.4.8",
     "eslint": "3.2.2",
     "jsonlint": "1.6.2",
+    "lodash": "4.14.2",
     "npm-check-updates": "2.8.0"
   },
   "keywords": [


### PR DESCRIPTION
Providing a way for route and state config to be passed
If routes.files and/or routes.state was passed, set it in the server
settings and then instantiate the server with those settings.