### PR TITLE
Feature/remove required layouts dir

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -20,7 +20,6 @@ class Config {
                 healthChecks: options.healthChecks || [],
                 host: process.env.HOST || options.host || '0.0.0.0',
                 loaderIoValidationKey: options.loaderIoValidationKey || undefined,
-                layoutsDir: options.layoutsDir || '',
                 maxListeners: process.env.DEFAULT_MAX_LISTENERS || options.maxListeners || 10,
                 name: options.name || name,
                 port: process.env.PORT || options.port || 3000,
@@ -94,14 +93,17 @@ class Config {
     }
 
     get connectionOptions() {
-        let connectionOptions = Object.create(null);
+        let connectionOptions = Object.create(null),
+            relativePath = (this.settings.layoutsDir !== undefined) ?
+                path.join(this.settings.basePath, this.settings.layoutsDir) :
+                this.settings.basePath;
 
         connectionOptions.host      = this.settings.host;
         connectionOptions.labels    = this.settings.environment || 'dev';
         connectionOptions.port      = this.settings.port;
         connectionOptions.tls       = (this.settings.tls) ? this.settings.tls : null;
         connectionOptions.routes    = (this.settings.routes) ? this.settings.routes : {};
-        connectionOptions.routes.files  = {relativeTo: path.join(this.settings.basePath, this.settings.layoutsDir)};
+        connectionOptions.routes.files  = {relativeTo: relativePath};
         connectionOptions.routes.cors   = {};
         connectionOptions.routes.state  = {};
 


### PR DESCRIPTION
# Why

The layoutsDir should not be required to spin up an API that does not have views. Removing the requirement to have layoutsDir.