### PR TITLE
update hapi to latest version for security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "good": "7.3.0",
     "good-console": "6.4.0",
     "good-squeeze": "5.0.2",
-    "hapi": "16.5.2",
+    "hapi": "16.6.0",
     "hapi-swagger": "7.7.1",
     "inert": "4.2.1",
     "podium": "1.3.0",


### PR DESCRIPTION
Update `hapi.js` to newest version (`16.6.0`) due to a security vulnerability.

https://twitter.com/hapijs/status/907708527182934016